### PR TITLE
Banner to get back to restaurant page

### DIFF
--- a/shelter-in-plates/src/App.vue
+++ b/shelter-in-plates/src/App.vue
@@ -3,6 +3,7 @@
     <top-nav />
     <router-view/>
     <app-footer />
+    <back-to-restaurant-banner />
   </div>
 </template>
 <script>

--- a/shelter-in-plates/src/components/BackToRestaurantBanner.vue
+++ b/shelter-in-plates/src/components/BackToRestaurantBanner.vue
@@ -1,0 +1,55 @@
+<template>
+    <div id="banner" v-if="entryRestaurantPageIsSet && !userIsOnEntryRestaurantPage">
+      <router-link :to="path" tag="a">
+          <span>Buy A Meal From {{ name }}</span>
+      </router-link>
+    </div>
+</template>
+<script>
+export default {
+  computed: {
+    entryRestaurantPageIsSet() {
+      return !(window.sessionStorage.entryRestaurantPath === undefined)
+    },
+    userIsOnEntryRestaurantPage() {
+      if (this.$router.currentRoute.path === window.sessionStorage.entryRestaurantPath) {
+        return true
+      }
+      return false
+    },
+    name() {
+      return window.sessionStorage.entryRestaurantName
+    },
+    path() {
+      return window.sessionStorage.entryRestaurantPath
+    }
+  }
+}
+</script>
+
+<style scoped lang="scss">
+#banner {
+    height: 5em;
+    background-color: #ffcf10;
+    text-align: center;
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    border-top: 2px solid white;
+    z-index: 999;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    a {
+      font-size: 1.5em;
+      font-weight: bold;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+}
+</style>
+

--- a/shelter-in-plates/src/components/BuyModal.vue
+++ b/shelter-in-plates/src/components/BuyModal.vue
@@ -122,7 +122,11 @@ export default {
             xhr.open('GET', url);
             xhr.send(null);
         },
+        clearEntryRestaurant() {
+            window.sessionStorage.clear()
+        },
         checkOut() {
+            this.clearEntryRestaurant()
             this.savePersonalMessage()
 
             const path = this.$router.resolve({

--- a/shelter-in-plates/src/main.js
+++ b/shelter-in-plates/src/main.js
@@ -8,6 +8,7 @@ import VueCurrencyFilter from 'vue-currency-filter'
 
 import TopNav from '@/components/TopNav.vue'
 import Footer from '@/components/Footer.vue'
+import BackToRestaurantBanner from '@/components/BackToRestaurantBanner.vue'
 import BuyModal from '@/components/BuyModal.vue'
 
 Vue.config.productionTip = false
@@ -15,6 +16,7 @@ Vue.config.productionTip = false
 Vue.component('top-nav', TopNav)
 Vue.component('app-footer', Footer)
 Vue.component('buy-modal', BuyModal)
+Vue.component('back-to-restaurant-banner', BackToRestaurantBanner)
 
 Vue.use(VueCurrencyFilter,
   {

--- a/shelter-in-plates/src/router/index.js
+++ b/shelter-in-plates/src/router/index.js
@@ -3,6 +3,7 @@ import VueRouter from 'vue-router'
 import Home from '../views/Home.vue'
 import LearnMore from '../views/LearnMore.vue'
 import HelpOut from '../views/HelpOut.vue'
+import CancelSubscription from '../views/CancelSubscription.vue'
 import Restaurant from '../views/Restaurant.vue'
 import Confirmation from '../views/Confirmation.vue'
 import NotFound from '../views/NotFound.vue'
@@ -29,6 +30,11 @@ const routes = [
     path: '/sample',
     name: 'sample',
     component: Restaurant
+  },
+  {
+    path: '/cancel',
+    name: 'cancel',
+    component: CancelSubscription
   },
   {
     path: '/r/:slug',

--- a/shelter-in-plates/src/views/CancelSubscription.vue
+++ b/shelter-in-plates/src/views/CancelSubscription.vue
@@ -1,0 +1,89 @@
+<template>
+    <div id="content">
+        <!-- Section -->
+        <section class="section bg-light">
+            <div class="container">
+                <div class="row mb-4">
+                    <div class="col-lg-7 push-lg-3">
+                        <div class="text-center mb-2">
+                            <span class="icon icon-md icon-danger"><i class="ti ti-heart"></i></span>
+                            <h2>Cancelling A Weekly Meal Purchase</h2>
+                        </div>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-lg-7 push-lg-3">
+                        <h3>Thank You!</h3>
+                        <p>First of all: A huge <strong>THANK YOU</strong>!</p>
+                        <p>You are amazing and you've already done so much to help support frontline healthcare workers &amp; independent restaurants.</p>
+                        <p>Second: We recognize that these are unprecedent, uncertain times. Just because someone was in a position to give last week does not mean they are in a position to give this week.</p>
+                        <p>For that reason: If, for ANY reason, it's no longer something you are able to do, we totally understand.</p>
+
+                        <h3>How To Cancel</h3>
+                        <p>Please just email us at <a class="link" href="mailto:admin@shelter-in-plates.com">admin@shelter-in-plates.com</a> with the name and/or email you used on the credit card transaction, and we will make sure your card is not charged again.</p>
+                        <p>If your card was already charged and you are unable to support that, please let us know and we will happily refund a charge even if it was already processed.</p>
+                        <p>Thank you for letting us be a part of this with you.</p>
+
+                        <!-- 
+                        <h3>How can you help?</h3>
+                        <p>Please share us with your friends on social media or ask others to join you in supporting restaurants and healthcare workers.</p>
+                        <p>Here are some sample messages you can copy &amp; paste:</p>
+                        <ul>
+                            <li>One of my favorite local restaurants, Irazu, is selling meals to feed frontline healthcare workers fighting Coronavirus. Join me in supporting them at https://www.shelter-in-plates.com/r/irazu/</li>
+                            <li>Join me and Irazu in feeding the front line: Join me in supporting independent restaurants and healthcare workers fighting covid-19! https://www.shelter-in-plates.com/r/irazu/</li>
+                        </ul>
+                        -->
+                    </div>
+                </div>
+            </div>
+        </section>
+    </div>
+</template>
+<script>
+
+export default {
+}
+</script>
+<style lang="scss" scoped>
+h2 {
+  font-size: 2.25rem;
+  font-weight: 400;
+}
+h3 {
+  font-size: 1.5rem;
+  font-weight: 400;
+}
+li, p {
+  color: #777 !important;
+}
+
+.module-social > * {
+  margin: 1rem 2rem;
+}
+
+a.link {
+    font-weight: 500;
+    text-decoration: underline;
+}
+a.icon {
+    cursor: pointer;
+
+    &.icon-circle {
+        color: white;
+
+        &:hover {
+          background-color: #aaa;
+        }
+    }
+
+    &.icon-instagram {
+        background-color: #4f86ac;
+    }
+    &.icon-twitter {
+        background-color: #3aa8db;
+    }
+    &.icon-facebook {
+        background-color: #3b5998;
+    }
+}
+</style>

--- a/shelter-in-plates/src/views/HelpOut.vue
+++ b/shelter-in-plates/src/views/HelpOut.vue
@@ -74,7 +74,10 @@
                         <div id="faq3_1" class="pb-5">
                             <h4>Purchase Meals For Healthcare Workers</h4>
                             <p class="lead">
+                                Email us at <a href="mailto:admin@shelter-in-plates.com">admin@shelter-in-plates.com</a> to see what restaurant we're currently working with and we'll send you a link to support them.
+                                <!--
                                 You can select to purchase meals from <a href="#">any participating restaurant here</a>! Just select how many you would like to purchase, add a personal note to the restaurant and health care workers, and we will take care of the rest.
+                                -->
                             </p>
                             <p class="lead">
                                 We will let you know when your order is received and when it is delivered to a local hospital in the next few days.

--- a/shelter-in-plates/src/views/Restaurant.vue
+++ b/shelter-in-plates/src/views/Restaurant.vue
@@ -118,6 +118,18 @@ export default {
         if(window.Core) {
             window.Core.navigation()
         }
+        this.setEntryRestaurant()
+
+    },
+    methods: {
+        setEntryRestaurant() {
+            if (!window.sessionStorage.entryRestaurantPath) {
+                window.sessionStorage.entryRestaurantPath = this.$router.currentRoute.path
+            }
+            if (!window.sessionStorage.entryRestaurantName) {
+                window.sessionStorage.entryRestaurantName = this.restaurant.name
+            }
+        }
     },
     data() {
         return {


### PR DESCRIPTION
@shchoi22 please review.

got feedback that users kept going to the restaurant buy page (/r/slug), then were getting curious, so they would click HOME or some other link away from the buy page.

From there, there aren't any links to find the buy page again, so they get lost and the transaction dies.

To solve:
1. use `sessionStorage` - if a user hits a restaurant page and doesn't have it already set, store the restaurant name and path.
2. on any page on the site, if the currentRoute.path does NOT equal the restaurant page path, display a fixed banner at the bottom that links back to the restaurant buy page.
3. if the user attempts to buy (from any restaurant), then remove the banner.